### PR TITLE
Interfaz y carga de citas

### DIFF
--- a/.github/workflows/pytest-flake8.yml
+++ b/.github/workflows/pytest-flake8.yml
@@ -21,4 +21,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run tests with pytest
+        working-directory: ./calendville
         run: pytest --flake8

--- a/calendville/appointments/templates/layout.html
+++ b/calendville/appointments/templates/layout.html
@@ -6,7 +6,9 @@
     <title>{% block title %} Calendville {% endblock %}</title>
 
     {% block header %}
-
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="stylesheet" href="{% static 'styles.css' %}">
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet"
               integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
@@ -34,6 +36,9 @@
             </li>
               {% if user.is_authenticated %}
                 <li class="nav-item">
+                    <a class="nav-link" href="{% url 'list_appointments' %}">Citas</a>
+                </li>
+                <li class="nav-item">
                     <a class="nav-link" href="{% url 'logout' %}">Cerrar sesión</a>
                 </li>
               {% else %}
@@ -48,10 +53,10 @@
 
 {% endblock %}
 
-<div class="container">
+<main class="container">
     {% block content %}
     {% endblock %}
-</div>
+</main>
 
 </body>
 </html>

--- a/calendville/appointments/templates/list_appointments.html
+++ b/calendville/appointments/templates/list_appointments.html
@@ -1,0 +1,40 @@
+{% extends "layout.html" %}
+
+{% block content %}
+
+<div>
+    {% for appointments_day in appointments_week %}
+        <div class="card mb-3">
+            <div class="card-header">
+                {{appointments_day.day}}
+            </div>
+            {% if not appointments_day.appointments %}
+                <div class="card-body">
+                    No hay citas
+                </div>
+            {% else %}
+                {% for appointment in appointments_day.appointments %}
+                    <div class="card-body border-bottom">
+                        <h5 class="card-title">
+                            <strong>Paciente: </strong>
+                            {{appointment.patient_id.name}} {{appointment.patient_id.last_name}}
+                        </h5>
+                        <div class="row">
+                            <div class="col-md-4">
+                                <strong>Fecha: </strong><span>{{ appointment.start_time }}</span>
+                            </div>
+                            <div class="col-md-4">
+                                <strong>Profesional: </strong><span>{{appointment.attended_by.name}} {{appointment.attended_by.last_name}}</span>
+                            </div>
+                            <div class="col-md-4">
+                                <strong>Registrada por: </strong><span>{{appointment.registered_by.name}} {{appointment.registered_by.last_name}}</span>
+                            </div>
+                        </div>
+                    </div>
+                {% endfor %}
+            {% endif %}
+        </div>
+    {% endfor %}
+</div>
+
+{% endblock %}

--- a/calendville/appointments/urls.py
+++ b/calendville/appointments/urls.py
@@ -6,5 +6,6 @@ urlpatterns = [
     path('', views.index, name="index"),
     path('login', views.login_view, name="login"),
     path('logout', views.logout_view, name="logout"),
-    path('register_appointment', views.register_appointment, name="register_appointment")
+    path('register_appointment', views.register_appointment,
+         name="register_appointment")
 ]

--- a/calendville/appointments/urls.py
+++ b/calendville/appointments/urls.py
@@ -7,5 +7,7 @@ urlpatterns = [
     path('login', views.login_view, name="login"),
     path('logout', views.logout_view, name="logout"),
     path('register_appointment', views.register_appointment,
-         name="register_appointment")
+         name="register_appointment"),
+    path('appointments', views.list_appointments,
+         name="list_appointments")
 ]

--- a/calendville/appointments/views.py
+++ b/calendville/appointments/views.py
@@ -2,9 +2,12 @@ from django.contrib.auth import logout, login, authenticate
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
-
-# Create your views here.
 from django.urls import reverse
+
+from datetime import date
+from datetime import timedelta
+
+from appointments.models import Appointment
 
 
 def index(request):
@@ -42,3 +45,23 @@ def logout_view(request):
 
 def register_appointment(request):
     return render(request, "register_appointment.html")
+
+
+@login_required(login_url='/login')
+def list_appointments(request):
+    start_date = date.today()
+
+    # Appointments for the next 7 days
+    appointments_week = [
+        {
+            "day": (start_date + timedelta(days=day)),
+            "appointments": Appointment.objects.filter(
+                start_time__date=(start_date + timedelta(days=day))
+            ).order_by('start_time')
+        }
+        for day in range(0, 7)
+    ]
+
+    return render(request, "list_appointments.html", {
+        "appointments_week": appointments_week,
+    })

--- a/calendville/appointments/views.py
+++ b/calendville/appointments/views.py
@@ -42,5 +42,3 @@ def logout_view(request):
 
 def register_appointment(request):
     return render(request, "register_appointment.html")
-
-

--- a/calendville/pytest.ini
+++ b/calendville/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = calendville.settings
 python_files = test_*.py
+norecursedirs = migrations calendville
+
 # See https://pypi.org/project/pytest-flake8/ for flake8 options

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ coverage==6.1.2
 distlib==0.3.3
 Django==3.2.9
 filelock==3.3.2
-flake8==4.0.1
+flake8==3.9.2
 importlib-metadata==4.2.0
 importlib-resources==5.4.0
 iniconfig==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ packaging==21.2
 platformdirs==2.4.0
 pluggy==1.0.0
 py==1.11.0
-pycodestyle==2.8.0
-pyflakes==2.4.0
+pycodestyle==2.7.0
+pyflakes==2.3.0
 pyparsing==2.4.7
 pytest==6.2.5
 pytest-cov==3.0.0


### PR DESCRIPTION
**Flake8:**
- Se bajó la versión de flake8 a 3.9.2 por errores en la
  última versión
- Se ignoran las carpetas calendville y migrations por
  ser código autogenerado
- Se arreglaron los errores de flake8 restantes

**Lista de citas:**
- Se agregaron metadatos al head y cambio de div por main
  en el layout para que el diseño se adapte a pantallas pequeñas
- Se agregó la ruta y la función que consulta la base de
  datos para las citas de la próxima semana
- Se asocian los usuarios del modelo Worker, puede ser
  necesario un cambio para asociar los datos usados para
  iniciar sesión