### PR TITLE
Fix authentication tests

### DIFF
--- a/calendville/tests/conftest.py
+++ b/calendville/tests/conftest.py
@@ -3,16 +3,18 @@ import pytest
 
 PASSWORD_KEY = "password"
 USERNAME_KEY = "email"
+DEFAULT_USERNAME = "user@example.com"
+DEFAULT_PASS = "strong-test-pass"
 
 
 @pytest.fixture
 def test_username():
-    return "user@example.com"
+    return DEFAULT_USERNAME
 
 
 @pytest.fixture
 def test_password():
-    return "strong-test-pass"
+    return DEFAULT_PASS
 
 
 @pytest.fixture

--- a/calendville/tests/test_login.py
+++ b/calendville/tests/test_login.py
@@ -3,9 +3,6 @@ from django.test import Client
 from django.urls import reverse
 
 from appointments.models import Worker
-from appointments.views import list_appointments
-from appointments.views import register_appointment
-from appointments.views import logout_view
 from appointments.views import login_view
 
 import pytest
@@ -78,7 +75,7 @@ class TestLogin:
         factory = RequestFactory()
         request = factory.post(path, data=bad_user)
 
-        # Notice that goo should be marked as unexisting
+        # Notice that DEFAULT_USERNAME should be marked as unexisting
         # since the create_user fixture is not getting called in this test
         with pytest.raises(Worker.DoesNotExist):
             login_view(request)

--- a/calendville/tests/test_login.py
+++ b/calendville/tests/test_login.py
@@ -1,7 +1,6 @@
 from django.test import RequestFactory
 from django.test import Client
 from django.urls import reverse
-from django.contrib.auth.models import AnonymousUser
 
 from appointments.models import Worker
 from appointments.views import list_appointments
@@ -9,9 +8,9 @@ from appointments.views import register_appointment
 from appointments.views import logout_view
 from appointments.views import login_view
 
-from mixer.backend.django import mixer
-
 import pytest
+
+from conftest import DEFAULT_USERNAME, DEFAULT_PASS, PASSWORD_KEY
 
 
 @pytest.mark.django_db
@@ -19,85 +18,90 @@ class TestLogin:
     HTTP_REDIRECT_CODE = 302
     HTTP_OK_CODE = 200
 
-    TEST_PATHS = [
-        "/appointments",
-        "/logout",
-        "/register_appointment",
-    ]
-
-    ACCESS_URLS = [
-        ("list_appointments", list_appointments),
-        ("register_appointment", register_appointment),
-        ("logout", logout_view)
+    TEST_PATH_CODE = [
+        ("list_appointments", HTTP_OK_CODE),
+        ("register_appointment", HTTP_OK_CODE),
+        ("logout", HTTP_REDIRECT_CODE)
     ]
 
     USERNAME_FIELD = "email"
     PASSWORD_FIELD = "password"
 
     GOOD_USER = {
-        USERNAME_FIELD: "good@mail.com",
-        PASSWORD_FIELD: "good_pass"
+        USERNAME_FIELD: DEFAULT_USERNAME,
+        PASSWORD_FIELD: DEFAULT_PASS
     }
 
-    BAD_CREDENTIALS = [
-        {
-            USERNAME_FIELD: "good@mail.com",
+    BAD_CREDENTIALS = {
+        "bad_pass": {
+            USERNAME_FIELD: DEFAULT_USERNAME,
             PASSWORD_FIELD: "bad_pass"
         },
-        {
+        "bad_mail": {
             USERNAME_FIELD: "bad@mail.com",
-            PASSWORD_FIELD: "good_pass"
+            PASSWORD_FIELD: DEFAULT_PASS
         },
-        {
+        "bad_credentials": {
             USERNAME_FIELD: "bad@mail.com",
             PASSWORD_FIELD: "bad_pass"
         },
-    ]
+    }
 
-    @pytest.mark.parametrize("path", TEST_PATHS)
-    def test_allowed_access(self, path):
-        user = mixer.blend(Worker)
+    @pytest.mark.parametrize("path, expected_code", TEST_PATH_CODE)
+    def test_allowed_access(self, logged_user, path, expected_code):
+        real_path = reverse(path)
+        client, user = logged_user()
+        response = client.get(real_path)
+
+        assert expected_code == response.status_code
+
+    @pytest.mark.parametrize("path", TEST_PATH_CODE)
+    def test_unallowed_access(self, path):
+        real_path = reverse(path[0])
         client = Client()
-        client.login(username=user.email, password=user.password)
-        response = client.get(path, follow=True)
-        assert self.HTTP_OK_CODE == response.status_code
-
-    @pytest.mark.parametrize("url_name, func", ACCESS_URLS)
-    def test_unallowed_access(self, url_name, func):
-        path = reverse(url_name)
-        request = RequestFactory().get(path)
-        request.user = AnonymousUser()
-        response = func(request)
+        response = client.get(real_path)
 
         assert self.HTTP_REDIRECT_CODE == response.status_code
 
-    @pytest.fixture
-    def new_user(self):
-        return Worker.objects.create_user(**self.GOOD_USER)
-
-    def test_unsuccessful_login(self, new_user):
+    def test_unsuccessful_login(self, create_user):
+        user = create_user()
         client = Client()
-        bad_pass_user = self.BAD_CREDENTIALS[0]
-        response = client.post("/login", bad_pass_user, follow=True)
+        bad_pass = self.BAD_CREDENTIALS["bad_pass"][PASSWORD_KEY]
+        response = client.login(username=user.email, password=bad_pass)
 
-        assert response.context["user"].is_authenticated is False
+        assert response is False
 
-    @pytest.mark.parametrize("bad_user", BAD_CREDENTIALS)
-    def test_unexisting_users_login(self, bad_user):
+    @pytest.mark.parametrize("bad_user_key", BAD_CREDENTIALS)
+    def test_unexisting_users_login(self, bad_user_key):
         path = reverse('login')
+        bad_user = self.BAD_CREDENTIALS[bad_user_key]
         factory = RequestFactory()
         request = factory.post(path, data=bad_user)
 
-        # Notice that good@mail.com should be marked as unexisting
-        # since the new_user fixture is not getting called in this test
+        # Notice that goo should be marked as unexisting
+        # since the create_user fixture is not getting called in this test
         with pytest.raises(Worker.DoesNotExist):
             login_view(request)
 
-    def test_five_attempts_blocked(self, new_user):
+    def test_five_attempts_blocked(self, create_user):
+        default_user = create_user()
         client = Client()
-        bad_pass_user = self.BAD_CREDENTIALS[0]
-        for attempt in range(0, 5):
-            client.post("/login", bad_pass_user, follow=True)
+        bad_pass = self.BAD_CREDENTIALS["bad_pass"]
 
-        response = client.post("/login", self.GOOD_USER, follow=True)
-        assert response.context["user"].is_authenticated is False
+        for attempt in range(0, 5):
+            client.post('/login', bad_pass)
+
+        user = Worker.objects.get(email=default_user.email)
+        assert user.password_attempts == 5 and user.is_active is False
+
+    def test_attempts_reset(self, create_user):
+        default_user = create_user()
+        client = Client()
+        bad_pass = self.BAD_CREDENTIALS["bad_pass"]
+
+        for attempt in range(0, 3):
+            client.post('/login', bad_pass)
+
+        client.post('/login', self.GOOD_USER)
+        user = Worker.objects.get(email=default_user.email)
+        assert user.password_attempts == 0 and user.is_active is True


### PR DESCRIPTION
Ahora las pruebas validan correctamente. Las pruebas del bloqueo de cuenta encontraron un par de defectos: 

- La cuenta se bloquea realmente hasta el 6to intento fallido
- El contador no se resetea cuando se escribe bien la clave antes de los 5 intentos
- Tomando en cuenta el defecto del inicio de sesión con cuentas inexistentes, la prueba `test_unexisting_users_login` puede ser cambiada en el futuro (no salta la excepción como tal)